### PR TITLE
Добавить возможность создавать Кастомные станции метро у модератора в отелях

### DIFF
--- a/app/Http/Controllers/Moderator/ObjectController.php
+++ b/app/Http/Controllers/Moderator/ObjectController.php
@@ -80,15 +80,22 @@ class ObjectController extends Controller
         $hotel->saveAddress($request->get('value'), $request->get('comment'));
       } else if ($type === 'metros') {
         $hotel->metros()->delete();
+        $custom = $request->get('metros_custom');
         $distance = $request->get('metros_time');
         $color = $request->get('metros_color');
         foreach ($request->get('metros', []) as $index => $metro) {
+          if ($custom[$index] === "1") {
+            $c = substr($color[$index], 1);
+          } else {
+            $c = $color[$index];
+          }
           $metros = [
             'name'     => $metro,
             'hotel_id' => $hotel->id,
             'distance' => $distance[$index],
-            'color'    => $color[$index]
-          ];
+            'color'    => $c,
+            'custom'   => $custom[$index]
+           ];
           Metro::create($metros);
         }
       } else if ($type === 'attr') {

--- a/app/Models/Metro.php
+++ b/app/Models/Metro.php
@@ -84,6 +84,11 @@ class Metro extends Model
     'name',
     'distance',
     'hotel_id',
+    'custom',
+  ];
+
+  protected $casts = [
+    'custom' => 'boolean',
   ];
 
   protected static function boot()

--- a/app/Models/Metro.php
+++ b/app/Models/Metro.php
@@ -3,23 +3,23 @@
 namespace App\Models;
 
 use Eloquent;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * App\Models\Metro
  *
- * @property int $id
- * @property string $color
- * @property string $name
- * @property int $distance
- * @property int $hotel_id
+ * @property int         $id
+ * @property string      $color
+ * @property string      $name
+ * @property int         $distance
+ * @property int         $hotel_id
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read Hotel $hotel
+ * @property-read Hotel  $hotel
  * @method static Builder|Metro newModelQuery()
  * @method static Builder|Metro newQuery()
  * @method static Builder|Metro query()
@@ -61,7 +61,7 @@ class Metro extends Model
     'grey',
     'lime',
     'teal',
-    'blue-gray'
+    'blue-gray',
   ];
 
   public const COLORS_HEX = [
@@ -76,7 +76,7 @@ class Metro extends Model
     'grey' => '808080',
     'lime' => '7fff00',
     'teal' => '30d5c8',
-    'blue-gray' => '77a1b5'
+    'blue-gray' => '77a1b5',
   ];
 
   protected $fillable = [

--- a/database/migrations/2022_01_24_105528_add_custom_in_metro_table.php
+++ b/database/migrations/2022_01_24_105528_add_custom_in_metro_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCustomInMetroTable extends Migration
+{
+  /**
+   * Run the migrations.
+   *
+   * @return void
+   */
+  public function up(): void
+  {
+    Schema::table('metros', function (Blueprint $table) {
+      $table->boolean('custom')->default(false)->after('hotel_id');
+    });
+  }
+
+  /**
+   * Reverse the migrations.
+   *
+   * @return void
+   */
+  public function down(): void
+  {
+    Schema::table('metros', function (Blueprint $table) {
+      $table->dropColumn(['custom']);
+    });
+  }
+}


### PR DESCRIPTION
**Техническое задание:**

1. Добавить возможность создавать Кастомные станции метро, даже тех городах, где их нету. Выбирать цвет ветки. Данный функционал необходим в кабинете Модератора в отелях

**База данных:** В таблице `Metros` добавлено `Boolean` поле `custom`, отвечает за то, как именно необходимо отображать метро у модератора
**Выполнить команду `php artisan optimize`**